### PR TITLE
Fixed error when importing large xml dumps.

### DIFF
--- a/src/org/mediawiki/importer/XmlDumpReader.java
+++ b/src/org/mediawiki/importer/XmlDumpReader.java
@@ -85,10 +85,16 @@ public class XmlDumpReader  extends DefaultHandler {
 	 */
 	public void readDump() throws IOException {
 		try {
+			System.setProperty("jdk.xml.totalEntitySizeLimit", String.valueOf(Integer.MAX_VALUE));
+
 			SAXParserFactory factory = SAXParserFactory.newInstance();
 			SAXParser parser = factory.newSAXParser();
-	
-			parser.parse(input, this);
+			Reader reader = new InputStreamReader(input,"UTF-8");
+			InputSource is = new InputSource(reader);
+			is.setEncoding("UTF-8");
+
+
+			parser.parse(is, this);
 		} catch (ParserConfigurationException e) {
 			throw (IOException)new IOException(e.getMessage()).initCause(e);
 		} catch (SAXException e) {


### PR DESCRIPTION
ERROR: The accumulated size of entities is "50,000,001" that exceeded the "50,000,000" limit set by "FEATURE_SECURE_PROCESSING" 

and `ArrayIndexOutOfBoundsException` when importing large XML files.

[The latest commit (2 years old) ](https://github.com/wikimedia/mediawiki-tools-mwdumper/commit/decb792e55a1bb28a08e1347b2df2e40f6e57ee5)fixed the original `ArrayIndexOutOfBoundsException`, but it still persists when building + importing from source. This PR fixes that issue, plus the additional bug at the top of the PR.

[1] https://www.mediawiki.org/wiki/Manual_talk:MWDumper#Exception_in_thread_.22main.22_java.lang.ArrayIndexOutOfBoundsException:_2048

[2] https://github.com/dbpedia/extraction-framework/issues/487#issuecomment-255297245