### PR TITLE
Apply community-suggested patch & bump version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>mwdumper</name>
   <groupId>org.wikimedia</groupId>
   <artifactId>mwdumper</artifactId>
-  <version>1.25</version>
+  <version>1.26</version>
   <packaging>jar</packaging>
   <url>http://www.mediawiki.org/wiki/MWDumper</url>
 

--- a/src/org/mediawiki/importer/XmlDumpReader.java
+++ b/src/org/mediawiki/importer/XmlDumpReader.java
@@ -28,6 +28,7 @@ package org.mediawiki.importer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import javax.xml.parsers.SAXParserFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.InputSource;
 
 public class XmlDumpReader  extends DefaultHandler {
 	InputStream input;
@@ -85,10 +87,12 @@ public class XmlDumpReader  extends DefaultHandler {
 	 */
 	public void readDump() throws IOException {
 		try {
-			SAXParserFactory factory = SAXParserFactory.newInstance();
-			SAXParser parser = factory.newSAXParser();
-	
-			parser.parse(input, this);
+                        SAXParserFactory factory = SAXParserFactory.newInstance();
+                        SAXParser parser = factory.newSAXParser();
+                        Reader reader = new InputStreamReader(input,"UTF-8");
+                        InputSource is = new InputSource(reader);
+                        is.setEncoding("UTF-8");
+                        parser.parse(is, this);
 		} catch (ParserConfigurationException e) {
 			throw (IOException)new IOException(e.getMessage()).initCause(e);
 		} catch (SAXException e) {


### PR DESCRIPTION
This adds the patch mentioned here:
https://www.mediawiki.org/wiki/Manual_talk:MWDumper#Exception_in_thread_.22main.22_java.lang.ArrayIndexOutOfBoundsException:_2048

It also bumps the version from 1.25 to 1.26. This does build correctly.